### PR TITLE
Added the GitHub Issue Management extension

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,6 +113,9 @@
                 <li>
                     <a href="https://sqlcetoolbox.codeplex.com/">SQL Server Compact and SQLite Toolbox</a>
                 </li>
+                <li>
+                    <a href="https://github.com/rprouse/GitHubExtension">GitHub Issue Management</a>
+                </li>
             </ul>
         </div>
     </section>


### PR DESCRIPTION
An open source (MIT License) GitHub extension for managing GitHub issues within Visual Studio. Currently on its 9th release, it supports VS 2010 through 2015.

Not to be confused with the official GitHub extension :wink: I am going to rename it to prevent confusion, thus the different name in the link to the current release.
